### PR TITLE
Works with FTS

### DIFF
--- a/sqlite3_lz4.c
+++ b/sqlite3_lz4.c
@@ -107,8 +107,10 @@ static void _lz4uncompress(sqlite3_context *ctx, int argc, sqlite3_value **argv)
 	const char *in = sqlite3_value_blob(argv[0]);
 
 	int out_len = read32(in);
+        if (out_len < 4) out_len = 4;
 
 	char *out = sqlite3_malloc(out_len);
+
 	int nread = LZ4_uncompress(4 + in, out, out_len);
 	if (nread < 0 || nread != in_len-4) {
 		// error

--- a/sqlite3_lz4.c
+++ b/sqlite3_lz4.c
@@ -38,13 +38,13 @@ static void _lz4compress(sqlite3_context *ctx, int argc, sqlite3_value **argv) {
 		return;
 	}
 
-        if (SQLITE_BLOB != sqlite3_value_type(argv[0])) {
+        if (SQLITE_TEXT != sqlite3_value_type(argv[0])) {
                 sqlite3_result_value(ctx, argv[0]);
                 return;
         }
 
 	int in_len = sqlite3_value_bytes(argv[0]);
-	const char *in = sqlite3_value_blob(argv[0]);
+	const char *in = sqlite3_value_text(argv[0]);
 
 	int out_buf_len = LZ4_compressBound(in_len);
 	char *out = sqlite3_malloc(4 + out_buf_len);
@@ -66,13 +66,13 @@ static void _lz4compresshc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
 		return;
 	}
 
-        if (SQLITE_BLOB != sqlite3_value_type(argv[0])) {
+        if (SQLITE3_TEXT != sqlite3_value_type(argv[0])) {
                 sqlite3_result_value(ctx, argv[0]);
                 return;
         }
 
 	int in_len = sqlite3_value_bytes(argv[0]);
-	const char *in = sqlite3_value_blob(argv[0]);
+	const char *in = sqlite3_value_text(argv[0]);
 
 	int out_buf_len = LZ4_compressBound(in_len);
 	char *out = sqlite3_malloc(4 + out_buf_len);
@@ -97,7 +97,6 @@ static void _lz4uncompress(sqlite3_context *ctx, int argc, sqlite3_value **argv)
                 sqlite3_result_value(ctx, argv[0]);
                 return;
         }
-
 	int in_len = sqlite3_value_bytes(argv[0]);
 	if (in_len <= 4) {
 		// return an empty buffer instead?
@@ -115,7 +114,7 @@ static void _lz4uncompress(sqlite3_context *ctx, int argc, sqlite3_value **argv)
 		return;
 	}
 
-	sqlite3_result_blob(ctx, out, out_len, sqlite3_free);
+	sqlite3_result_text(ctx, out, out_len, sqlite3_free);
 }
 
 

--- a/sqlite3_lz4.c
+++ b/sqlite3_lz4.c
@@ -38,8 +38,8 @@ static void _lz4compress(sqlite3_context *ctx, int argc, sqlite3_value **argv) {
 		return;
 	}
 
-        if (SQLITE_NULL == sqlite3_value_type(argv[0])) {
-                sqlite3_result_null(ctx);
+        if (SQLITE_BLOB != sqlite3_value_type(argv[0])) {
+                sqlite3_result_value(ctx, argv[0]);
                 return;
         }
 
@@ -66,11 +66,10 @@ static void _lz4compresshc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
 		return;
 	}
 
-        if (SQLITE_NULL == sqlite3_value_type(argv[0])) {
-                sqlite3_result_null(ctx);
+        if (SQLITE_BLOB != sqlite3_value_type(argv[0])) {
+                sqlite3_result_value(ctx, argv[0]);
                 return;
         }
-
 
 	int in_len = sqlite3_value_bytes(argv[0]);
 	const char *in = sqlite3_value_blob(argv[0]);
@@ -94,8 +93,8 @@ static void _lz4uncompress(sqlite3_context *ctx, int argc, sqlite3_value **argv)
 		return;
 	}
 
-        if (SQLITE_NULL == sqlite3_value_type(argv[0])) {
-                sqlite3_result_null(ctx);
+        if (SQLITE_BLOB != sqlite3_value_type(argv[0])) {
+                sqlite3_result_value(ctx, argv[0]);
                 return;
         }
 

--- a/sqlite3_lz4.c
+++ b/sqlite3_lz4.c
@@ -49,7 +49,7 @@ static void _lz4compress(sqlite3_context *ctx, int argc, sqlite3_value **argv) {
 	int out_buf_len = LZ4_compressBound(in_len);
 	char *out = sqlite3_malloc(4 + out_buf_len);
 	int out_len = LZ4_compress(in, 4 + out, in_len);
-	if (out_len < 0) {
+	if (out_len <= 0) {
 		// error
 		sqlite3_free(out);
 		return;
@@ -67,17 +67,19 @@ static void _lz4compresshc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
 	}
 
         if (SQLITE3_TEXT != sqlite3_value_type(argv[0])) {
+
                 sqlite3_result_value(ctx, argv[0]);
                 return;
         }
 
 	int in_len = sqlite3_value_bytes(argv[0]);
+
 	const char *in = sqlite3_value_text(argv[0]);
 
 	int out_buf_len = LZ4_compressBound(in_len);
 	char *out = sqlite3_malloc(4 + out_buf_len);
 	int out_len = LZ4_compressHC(in, 4 + out, in_len);
-	if (out_len < 0) {
+	if (out_len <= 0) {
 		// error
 		sqlite3_free(out);
 		return;


### PR DESCRIPTION
This is a bit more wideranging - now compress and uncompress are no-ops on non-blob data.

However, you may not want to accept this patch - it now only compresses text, not blobs. This is adequate for me, but will obviously break existing code. I think a full solution would have to store the sqlite3 datatype inside the compressed data and rehydrate it appropriately.

This also fixes some improper uses of LZ4 - empty strings should now work, and failed compression is correctly detected.

Fixes #6 
